### PR TITLE
Enable CI on pushes/pull requests to the dev branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
   push:
     branches:
       - main
+      - dev
   # and on all pull requests to the main branch
   pull_request:
     branches:
       - main
+      - dev
   # as well as upon manual triggers through the 'Actions' tab of the Github UI
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
CI is already set up, it is just not run for you because you work on `dev` instead of `main`.