### PR TITLE
fix scroll behaviour for numeric widgets

### DIFF
--- a/clickqt/widgets/basewidget.py
+++ b/clickqt/widgets/basewidget.py
@@ -77,6 +77,16 @@ class BaseWidget(ABC):
         self.focus_out_validator = clickqt.core.FocusOutValidator(self)
         self.widget.installEventFilter(self.focus_out_validator)
 
+        self.widget.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
+        def handlewheel(event):
+            if self.widget.hasFocus():
+                self.widget_type.wheelEvent(self.widget, event)
+            else:
+                event.ignore()
+
+        self.widget.wheelEvent = handlewheel  # Disable scrolling
+
     def create_widget(self) -> QWidget:
         """Creates the widget specified in :attr:`~clickqt.widgets.basewidget.BaseWidget.widget_type` and returns it."""
 

--- a/clickqt/widgets/numericfields.py
+++ b/clickqt/widgets/numericfields.py
@@ -28,8 +28,6 @@ class IntField(NumericField):
             otype, (click.IntRange, type(click.INT))
         ), f"'otype' must be of type '{click.IntRange}' or '{type(click.INT)}', but is '{type(otype)}'."
 
-        self.widget.wheelEvent = lambda *event: None # Disable scrolling
-
         if not isinstance(otype, click.IntRange):
             # QSpinBox is limited to [-2**31; 2**31 - 1], but sys.maxsize returns 2**63 - 1
             self.set_minimum(-(2**31))  # Default is 0
@@ -63,8 +61,6 @@ class RealField(NumericField):
         assert isinstance(
             otype, (click.FloatRange, type(click.FLOAT))
         ), f"'otype' must be of type '{click.FloatRange}' or '{type(click.FLOAT)}', but is '{type(otype)}'."
-
-        self.widget.wheelEvent = lambda *event: None # Disable scrolling
 
         if not isinstance(otype, click.FloatRange):
             self.set_minimum(-sys.float_info.max)  # Default is 0.0


### PR DESCRIPTION
mouse scrolls past numeric widgets now, the scroll event is only used when the focus of the widget was gained differently, i.e. when clicked.